### PR TITLE
Enable HACS installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Custom UI components for Home Assistant.
 
-This repository now uses a structure similar to the one from the [Mushroom Cards](https://github.com/piitaya/lovelace-mushroom) project. The source files live in the `src` directory and are written in TypeScript. Running `npm run build` compiles the code to JavaScript under the `www` folder.
+This repository now uses a structure similar to the one from the [Mushroom Cards](https://github.com/piitaya/lovelace-mushroom) project. The source files live in the `src` directory and are written in TypeScript. Built JavaScript files are included under the `www` folder so no additional build step is required for installation.
 
 ## hello-world-card
 
@@ -10,15 +10,16 @@ A simple custom card that displays "hello world!" inside an `ha-card`.
 
 ### Installation
 
-1. Install dependencies and build the project:
+#### Using HACS
 
-```bash
-npm install
-npm run build
-```
+1. Add this repository as a custom repository of type **plugin** in HACS.
+2. Install **dihor-ha-components** from the HACS UI.
+3. Reload Lovelace resources.
 
-2. Copy `www/cards/hello-world-card.js` to the `www` folder of your Home Assistant configuration directory.
-3. Add the following to your Lovelace resources:
+#### Manual
+
+1. Copy `www/cards/hello-world-card.js` to the `www` folder of your Home Assistant configuration directory (no build step required).
+2. Add the following to your Lovelace resources:
 
 ```yaml
 - url: /local/cards/hello-world-card.js

--- a/hacs.json
+++ b/hacs.json
@@ -1,0 +1,7 @@
+{
+  "name": "dihor-ha-components",
+  "filename": "www/cards/hello-world-card.js",
+  "type": "module",
+  "render_readme": true,
+  "description": "Custom UI components for Home Assistant"
+}


### PR DESCRIPTION
## Summary
- add `hacs.json` with metadata for HACS
- update README to document HACS usage and remove build step

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6844821b645c8328aa6a0f55f57ec209