### PR TITLE
Fix HACS integration path

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,17 +16,17 @@ A simple custom card that displays "hello world!" inside an `ha-card`.
 2. Install **dihor-ha-components** from the HACS UI.
 3. Reload Lovelace resources.
 4. HACS should register the resource
-   `/hacsfiles/dihor-ha-components/www/cards/dihor-hello-world-card.js` automatically.
+   `/hacsfiles/dihor-ha-components/dihor-hello-world-card.js` automatically.
    If it is missing, add this path manually to your Lovelace resources as a
    module.
 
 #### Manual
 
-1. Copy `www/cards/dihor-hello-world-card.js` to the `www` folder of your Home Assistant configuration directory (no build step required).
+1. Copy `dihor-hello-world-card.js` to the `www` folder of your Home Assistant configuration directory (no build step required).
 2. Add the following to your Lovelace resources:
 
 ```yaml
-- url: /local/cards/dihor-hello-world-card.js
+- url: /local/dihor-hello-world-card.js
   type: module
 ```
 

--- a/dihor-hello-world-card.js
+++ b/dihor-hello-world-card.js
@@ -1,0 +1,1 @@
+import "./www/cards/dihor-hello-world-card.js";

--- a/hacs.json
+++ b/hacs.json
@@ -1,6 +1,6 @@
 {
   "name": "dihor-ha-components",
-  "filename": "www/cards/dihor-hello-world-card.js",
+  "filename": "dihor-hello-world-card.js",
   "type": "module",
   "render_readme": true,
   "description": "Custom UI components for Home Assistant"


### PR DESCRIPTION
## Summary
- create top-level entrypoint for the `dihor-hello-world-card` plugin
- update `hacs.json` to reference the new entrypoint
- adjust README instructions accordingly

## Testing
- `npm --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844928f72488328add5fe3fa64c555c