### PR TITLE
Fix hello-world card

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,3 +39,4 @@ Add the card in your dashboard YAML:
 ```
 
 That's it! You should now see a card with the text "hello world!".
+

--- a/src/cards/dihor-hello-world-card.ts
+++ b/src/cards/dihor-hello-world-card.ts
@@ -1,15 +1,34 @@
-export class HelloWorldCard extends HTMLElement {
-  private content: boolean = false;
-  private _config: any;
+export interface HelloWorldCardConfig {
+  entity?: string;
+}
 
-  setConfig(config: any) {
+export class HelloWorldCard extends HTMLElement {
+  private _hass: any;
+  private _config!: HelloWorldCardConfig;
+  private _contentCreated = false;
+
+  setConfig(config: HelloWorldCardConfig) {
     this._config = config;
   }
 
   set hass(hass: any) {
-    if (!this.content) {
-      this.innerHTML = `\n        <ha-card header="Hello">\n          <div class="card-content">hello world!</div>\n        </ha-card>\n      `;
-      this.content = true;
+    this._hass = hass;
+    const state = this._config.entity
+      ? hass.states[this._config.entity]?.state
+      : undefined;
+
+    if (!this._contentCreated) {
+      this.innerHTML = `
+        <ha-card header="Hello">
+          <div class="card-content"></div>
+        </ha-card>
+      `;
+      this._contentCreated = true;
+    }
+
+    const contentEl = this.querySelector('.card-content');
+    if (contentEl) {
+      contentEl.textContent = state ? `hello ${state}!` : 'hello world!';
     }
   }
 

--- a/www/cards/dihor-hello-world-card.js
+++ b/www/cards/dihor-hello-world-card.js
@@ -1,15 +1,28 @@
 export class HelloWorldCard extends HTMLElement {
     constructor() {
         super(...arguments);
-        this.content = false;
+        this._contentCreated = false;
     }
     setConfig(config) {
         this._config = config;
     }
     set hass(hass) {
-        if (!this.content) {
-            this.innerHTML = `\n        <ha-card header="Hello">\n          <div class="card-content">hello world!</div>\n        </ha-card>\n      `;
-            this.content = true;
+        var _a;
+        this._hass = hass;
+        const state = this._config.entity
+            ? (_a = hass.states[this._config.entity]) === null || _a === void 0 ? void 0 : _a.state
+            : undefined;
+        if (!this._contentCreated) {
+            this.innerHTML = `
+        <ha-card header="Hello">
+          <div class="card-content"></div>
+        </ha-card>
+      `;
+            this._contentCreated = true;
+        }
+        const contentEl = this.querySelector('.card-content');
+        if (contentEl) {
+            contentEl.textContent = state ? `hello ${state}!` : 'hello world!';
         }
     }
     getCardSize() {


### PR DESCRIPTION
## Summary
- remove example floorplan card
- update hello-world card to optionally display an entity state

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684498373d788328a3c4f5412dd48949