### PR TITLE
Fix HACS resource path

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ A simple custom card that displays "hello world!" inside an `ha-card`.
 3. Reload Lovelace resources.
 4. HACS should register the resource
    `/hacsfiles/dihor-ha-components/dihor-hello-world-card.js` automatically.
+   This is the same file that is accessible via
+   `/local/community/dihor-ha-components/dihor-hello-world-card.js`.
    If it is missing, add this path manually to your Lovelace resources as a
    module.
 

--- a/hacs.json
+++ b/hacs.json
@@ -1,6 +1,7 @@
 {
   "name": "dihor-ha-components",
   "filename": "dihor-hello-world-card.js",
+  "content_in_root": true,
   "type": "module",
   "render_readme": true,
   "description": "Custom UI components for Home Assistant"


### PR DESCRIPTION
## Summary
- ensure the card file is recognized at the repository root by setting `content_in_root: true` in `hacs.json`

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6844a013889c8328826e3a3972aedc49