### PR TITLE
Add CSS theme system and dark mode

### DIFF
--- a/src/cards/minecraft/dihor-minecraft-card.css
+++ b/src/cards/minecraft/dihor-minecraft-card.css
@@ -1,12 +1,12 @@
 /* KARTA */
 .dihor-card {
   margin: 0;
-  background: rgba(255, 255, 255, 0.95);
+  background: var(--dihor-card-bg);
   backdrop-filter: blur(20px);
-  border-radius: 12px;
+  border-radius: var(--dihor-card-border-radius);
   padding: 18px;
-  box-shadow: 0 15px 35px rgba(0, 0, 0, 0.1);
-  border: 1px solid rgba(255, 255, 255, 0.2);
+  box-shadow: var(--dihor-card-shadow);
+  border: var(--dihor-card-border-size) solid var(--dihor-card-border-color);
   font-family: sans-serif;
 }
 
@@ -14,7 +14,7 @@
 .dihor-card-header {
   margin-bottom: 16px;
   padding-bottom: 12px;
-  border-bottom: 1px solid rgba(0, 0, 0, 0.08);
+  border-bottom: 1px solid var(--dihor-divider-color);
 }
 
 .dihor-header-row {
@@ -27,13 +27,13 @@
 .dihor-card-title {
   font-size: 20px;
   font-weight: 700;
-  color: #1d1d1f;
+  color: var(--dihor-title-color);
   margin: 0;
 }
 
 .dihor-card-subtitle {
   font-size: 14px;
-  color: #666;
+  color: var(--dihor-subtitle-color);
   font-weight: 500;
 }
 
@@ -53,8 +53,8 @@
   flex-direction: column;
   align-items: center;
   padding: 10px 0;
-  background: rgba(200, 200, 200, 0.2);
-  border-radius: 12px;
+  background: var(--dihor-stat-bg);
+  border-radius: var(--dihor-card-border-radius);
   text-align: center;
 }
 
@@ -64,7 +64,7 @@
 
 .dihor-stat-label {
   font-size: 11px;
-  color: #666;
+  color: var(--dihor-subtitle-color);
   font-weight: 500;
   margin-bottom: 4px;
   text-transform: uppercase;
@@ -73,7 +73,7 @@
 
 .dihor-stat-value {
   font-size: 14px;
-  color: #1d1d1f;
+  color: var(--dihor-title-color);
   font-weight: 600;
   line-height: 1.2;
 }
@@ -88,21 +88,21 @@
 }
 
 .dihor-badge-online {
-  background: #4caf50;
+  background: var(--dihor-badge-online-bg);
 }
 
 .dihor-badge-offline {
-  background: #ff3b30;
+  background: var(--dihor-badge-offline-bg);
 }
 
 .dihor-badge-players {
-  background: #9c27b0;
+  background: var(--dihor-badge-players-bg);
 }
 
 .dihor-badge-version {
-  background: #007aff;
+  background: var(--dihor-badge-version-bg);
 }
 
 .dihor-badge-latency {
-  background: #ff9500;
+  background: var(--dihor-badge-latency-bg);
 }

--- a/src/cards/minecraft/dihor-minecraft-card.ts
+++ b/src/cards/minecraft/dihor-minecraft-card.ts
@@ -1,5 +1,6 @@
 import html from "./dihor-minecraft-card.html";
 import css from "./dihor-minecraft-card.css";
+import themeCss from "../../theme.css";
 
 export interface MinecraftCardConfig {
   title?: string;
@@ -41,12 +42,19 @@ export class MinecraftCard extends HTMLElement {
 
     if (!this._contentCreated) {
       this.innerHTML = `
+        <style>${themeCss}</style>
         <ha-card>
           ${html}
           <style>${css}</style>
         </ha-card>
       `;
       this._contentCreated = true;
+    }
+    const haCard = this.querySelector('ha-card');
+    const dark = hass.themes?.darkMode;
+    if (haCard) {
+      haCard.classList.toggle('dihor-theme-dark', !!dark);
+      haCard.classList.toggle('dihor-theme-light', !dark);
     }
 
     const updateText = (id: string, value: string) => {

--- a/src/cards/person/dihor-person-card.ts
+++ b/src/cards/person/dihor-person-card.ts
@@ -1,3 +1,5 @@
+import themeCss from "../../theme.css";
+
 export interface PersonCardConfig {
   entity: string;
 }
@@ -25,6 +27,7 @@ export class PersonCard extends HTMLElement {
 
     if (!this._contentCreated) {
       this.innerHTML = `
+        <style>${themeCss}</style>
         <ha-card header="${name}">
           <div class="card-content">
             <img style="width:100%;border-radius:50%" />
@@ -37,6 +40,12 @@ export class PersonCard extends HTMLElement {
       if (haCard) {
         haCard.setAttribute('header', name);
       }
+    }
+    const haCard = this.querySelector('ha-card');
+    const dark = hass.themes?.darkMode;
+    if (haCard) {
+      haCard.classList.toggle('dihor-theme-dark', !!dark);
+      haCard.classList.toggle('dihor-theme-light', !dark);
     }
 
     const img = this.querySelector('img');

--- a/src/theme.css
+++ b/src/theme.css
@@ -1,0 +1,40 @@
+/* Style variables for dihor cards */
+.dihor-theme-light {
+  --dihor-card-bg: rgba(255, 255, 255, 0.95);
+  --dihor-card-border-size: 1px;
+  --dihor-card-border-radius: 12px;
+  --dihor-card-border-color: rgba(255, 255, 255, 0.2);
+  --dihor-card-shadow: 0 15px 35px rgba(0, 0, 0, 0.1);
+
+  --dihor-title-color: #1d1d1f;
+  --dihor-subtitle-color: #666;
+  --dihor-stat-bg: rgba(200, 200, 200, 0.2);
+
+  --dihor-badge-online-bg: #4caf50;
+  --dihor-badge-offline-bg: #ff3b30;
+  --dihor-badge-players-bg: #9c27b0;
+  --dihor-badge-version-bg: #007aff;
+  --dihor-badge-latency-bg: #ff9500;
+
+  --dihor-divider-color: rgba(0, 0, 0, 0.08);
+}
+
+.dihor-theme-dark {
+  --dihor-card-bg: rgba(48, 48, 48, 0.95);
+  --dihor-card-border-size: 1px;
+  --dihor-card-border-radius: 12px;
+  --dihor-card-border-color: rgba(255, 255, 255, 0.1);
+  --dihor-card-shadow: 0 15px 35px rgba(0, 0, 0, 0.5);
+
+  --dihor-title-color: #f3f3f3;
+  --dihor-subtitle-color: #aaa;
+  --dihor-stat-bg: rgba(80, 80, 80, 0.5);
+
+  --dihor-badge-online-bg: #4caf50;
+  --dihor-badge-offline-bg: #ff3b30;
+  --dihor-badge-players-bg: #9c27b0;
+  --dihor-badge-version-bg: #007aff;
+  --dihor-badge-latency-bg: #ff9500;
+
+  --dihor-divider-color: rgba(255, 255, 255, 0.1);
+}


### PR DESCRIPTION
## Summary
- add reusable `theme.css` with light & dark variables
- use CSS variables in `dihor-minecraft-card.css`
- apply theme classes based on Home Assistant dark mode
- include theme styles for person card

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686faea4a448832893a4f24ddf9677ee