### PR TITLE
Fix theme path in person and clock cards

### DIFF
--- a/src/cards/clock/dihor-clock-card.ts
+++ b/src/cards/clock/dihor-clock-card.ts
@@ -1,6 +1,6 @@
 import html from "./dihor-clock-card.html";
 import css from "./dihor-clock-card.css";
-import themeCss from "../../theme.css";
+import themeCss from "../theme.css";
 
 export interface ClockCardConfig {
   size?: number;

--- a/src/cards/person/dihor-person-card.ts
+++ b/src/cards/person/dihor-person-card.ts
@@ -1,4 +1,4 @@
-import themeCss from "../../theme.css";
+import themeCss from "../theme.css";
 
 export interface PersonCardConfig {
   entity: string;


### PR DESCRIPTION
## Summary
- fix the relative import path for `theme.css` in clock and person cards
- ensure rollup build succeeds

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68714315d6048328a8b20511c1c8a536