### PR TITLE
Define HomeAssistant typing

### DIFF
--- a/src/cards/base.ts
+++ b/src/cards/base.ts
@@ -1,7 +1,8 @@
 import themeCss from "./theme.css";
+import type { HomeAssistant } from "../../types/home-assistant";
 
 export abstract class BaseDihorCard<ConfigType> extends HTMLElement {
-  protected _hass: any;
+  protected _hass!: HomeAssistant;
   protected _config!: ConfigType;
   private _contentCreated = false;
 
@@ -9,7 +10,7 @@ export abstract class BaseDihorCard<ConfigType> extends HTMLElement {
     this._config = config;
   }
 
-  set hass(hass: any) {
+  set hass(hass: HomeAssistant) {
     this._hass = hass;
     if (!this._contentCreated) {
       this.innerHTML = `
@@ -27,7 +28,7 @@ export abstract class BaseDihorCard<ConfigType> extends HTMLElement {
     this.update(hass);
   }
 
-  private applyTheme(hass: any) {
+  private applyTheme(hass: HomeAssistant) {
     const haCard = this.querySelector("ha-card");
     const dark = hass.themes?.darkMode;
     if (haCard) {
@@ -47,5 +48,5 @@ export abstract class BaseDihorCard<ConfigType> extends HTMLElement {
 
   protected onCardCreated(): void {}
 
-  protected update(_hass: any): void {}
+  protected update(_hass: HomeAssistant): void {}
 }

--- a/src/cards/minecraft/dihor-minecraft-card.ts
+++ b/src/cards/minecraft/dihor-minecraft-card.ts
@@ -3,6 +3,7 @@ import html from "./dihor-minecraft-card.html";
 import coreCss from "../core.css";
 import css from "./dihor-minecraft-card.css";
 import { BaseDihorCard } from "../base";
+import type { HomeAssistant } from "../../../types/home-assistant";
 
 export interface MinecraftCardConfig {
   title?: string;
@@ -38,7 +39,7 @@ export class MinecraftCard extends BaseDihorCard<MinecraftCardConfig> {
     return css;
   }
 
-  protected update(hass: any) {
+  protected update(hass: HomeAssistant) {
     const p = this._config.entity_prefix;
 
     const getState = (suffix: string): string => {

--- a/src/cards/person/dihor-person-card.ts
+++ b/src/cards/person/dihor-person-card.ts
@@ -1,4 +1,5 @@
 import { BaseDihorCard } from "../base";
+import type { HomeAssistant } from "../../../types/home-assistant";
 
 export interface PersonCardConfig {
   entity: string;
@@ -21,7 +22,7 @@ export class PersonCard extends BaseDihorCard<PersonCardConfig> {
     `;
   }
 
-  protected update(hass: any) {
+  protected update(hass: HomeAssistant) {
     const state = hass.states[this._config.entity];
     if (!state) {
       return;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,5 +7,5 @@
     "lib": ["es2018", "dom"],
     "skipLibCheck": true
   },
-  "include": ["src/**/*", "rollup.config.js", "types/raw.d.ts"]
+  "include": ["src/**/*", "rollup.config.js", "types/raw.d.ts", "types/home-assistant.d.ts"]
 }

--- a/types/home-assistant.d.ts
+++ b/types/home-assistant.d.ts
@@ -1,0 +1,9 @@
+export interface HomeAssistant {
+  states: Record<string, {
+    state: string;
+    attributes: Record<string, any>;
+  }>;
+  themes?: {
+    darkMode?: boolean;
+  };
+}


### PR DESCRIPTION
## Summary
- define minimal `HomeAssistant` interface
- reference `HomeAssistant` in base card and card implementations
- add new type file to TypeScript config

## Testing
- `npx tsc --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_68716a0cd1608328801e71cc1acab2d0