### PR TITLE
Update theme detection for dark mode

### DIFF
--- a/src/cards/base.ts
+++ b/src/cards/base.ts
@@ -24,13 +24,16 @@ export abstract class BaseDihorCard<ConfigType> extends HTMLElement {
       this._contentCreated = true;
       this.onCardCreated();
     }
-    this.applyTheme(hass);
+    this.applyTheme();
     this.update(hass);
   }
 
-  private applyTheme(hass: HomeAssistant) {
+  private applyTheme() {
     const haCard = this.querySelector("ha-card");
-    const dark = hass.themes?.darkMode;
+    const haElement = document.querySelector("home-assistant") as
+      | { hass?: HomeAssistant }
+      | null;
+    const dark = haElement?.hass?.themes?.darkMode;
     if (haCard) {
       haCard.classList.toggle("dihor-theme-dark", !!dark);
       haCard.classList.toggle("dihor-theme-light", !dark);


### PR DESCRIPTION
## Summary
- detect dark mode from the `home-assistant` element directly

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_687190d78c60832882468824c46f85b0