### PR TITLE
Add live preview clock

### DIFF
--- a/docs/clock.js
+++ b/docs/clock.js
@@ -1,0 +1,27 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const preview = document.getElementById('clock-card-preview');
+  if (!preview) return;
+
+  const updateTime = () => {
+    const timeEl = preview.querySelector('#time');
+    if (timeEl) {
+      timeEl.textContent = new Date().toLocaleTimeString([], {
+        hour: '2-digit',
+        minute: '2-digit',
+        second: '2-digit',
+      });
+    }
+  };
+
+  const waitForTimeEl = () => {
+    if (preview.querySelector('#time')) {
+      updateTime();
+      setInterval(updateTime, 1000);
+    } else {
+      requestAnimationFrame(waitForTimeEl);
+    }
+  };
+
+  waitForTimeEl();
+});
+

--- a/docs/index.html
+++ b/docs/index.html
@@ -239,5 +239,6 @@
         loadCardPreview();
       });
     </script>
+    <script src="clock.js"></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- add a standalone `clock.js` script to update the clock preview
- include `clock.js` in `docs/index.html`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68723bb0ee5c8328b8af6df16e81dad9